### PR TITLE
Fix for Atkinson Hyperlegible

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -14,11 +14,7 @@ jobs:
       - name: Install Sphinx/Doxygen
         run: |
           sudo apt update
-          sudo apt install -y libpoppler-cpp-dev
-      - name: Install Python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
+          sudo apt install -y libpoppler-cpp-dev python3-pip
       - name: Install Python Requirements
         run: |
           python -m pip install --upgrade pip

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,16 @@
+/* Import from Google Fonts, a CDN, or files in your _static folder.
+   This Google Fonts import provides its own `@font-face` CSS;
+   if providing your own font files, you'll also need to
+   provide your own `@font-face` code. */
+@import url("https://fonts.googleapis.com/css?family=Atkinson+Hyperlegible");
+
+/* Main font used throughout the docs. */
+body {
+  font-family: "Atkinson Hyperlegible", sans-serif;
+}
+
+/* Code snippets. */
+pre, code, kbd, samp {
+  font-family: "Courier New", monospace;
+}
+


### PR DESCRIPTION
The Braille Institute Atkinson Hyperlegible font was not being pulled in because the `custom.css` file had not been added to the repo.