### PR TITLE
Make report entries alphabetic

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -190,6 +190,8 @@ for pdfpath in glob.glob("../../pdfs/**/*.pdf"):
     f.write(embed_string.format(stub + ".pdf"))
     f.close()
 
+rst_names.sort()
+
 # create the file that we want to embed the pdfs in and start a toctree
 f = open("embeddedpdfs.rst", "w")
 f.write("Technical Reports\n")
@@ -200,6 +202,7 @@ for dirname in sorted(set(numbered_to_descriptive_dirs.values())):
     f.write("    {0}\n".format(dirname))
 f.close()
 # now create an .rst file for each of the toctree entries in numbered_to_descriptive_dirs
+
 for key in numbered_to_descriptive_dirs:
     dirname = numbered_to_descriptive_dirs[key]
     f = open("./" + dirname + ".rst", "w")


### PR DESCRIPTION
Prior to this PR, the reports are not ordered under each keyword-institute heading. I've sorted the list of strings, which causes the rst files to be written with the reports in an alphabetical order.